### PR TITLE
Improve gakoci to now consider PR number as an argument for PR hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,22 @@ Push hook files take 6 arguments:
     <payload.json> <event_type> <repo_owner> <repo_name> <branch> <commit_sha1>
     push-monperrus-spoon /home/spirals/mmonperr/tmpmzhmhr3d push monperrus spoon cleaning1 4c651dae33df8d8b339487a2c5d825f1c99e54e7
 
-Pull-request hook files take 8 arguments:
+Be careful, the arguments are used in bash script file, then counting args start at 1 for payload.json.
 
-    <payload.json> <event_type> <repo_owner> <repo_name> <branch> <commit_sha1> <base_owner> <base_repo>
+Typical pull request job for Java/Maven use the PR branch retrieved on Github (see GitHub instruction [here](https://help.github.com/articles/checking-out-pull-requests-locally/)):
+
+    #!/bin/bash
+    git init
+    echo git://github.com/$4/$5.git
+    git remote -v add -t $5 origin git://github.com/$3/$4.git
+    git fetch origin pull/$9/head:gakoci
+    git checkout gakoci
+    mvn clean test 2>&1 | tee trace.txt
+    exit ${PIPESTATUS[0]}
+
+Pull-request hook files take 9 arguments:
+
+    <payload.json> <event_type> <repo_owner> <repo_name> <branch> <commit_sha1> <base_owner> <base_repo> <pr_number>
 
 
 ## Motivation

--- a/gakoci.py
+++ b/gakoci.py
@@ -88,7 +88,7 @@ class PullRequestAction(EventAction):
         return self.scripts
 
     def arguments(self):
-        return [self.payload_path, self.meta_info['event_type'], self.meta_info['owner'], self.meta_info['repo'], self.meta_info['branch'], self.meta_info['commit'], self.meta_info['base_owner'], self.meta_info['base_repo']]
+        return [self.payload_path, self.meta_info['event_type'], self.meta_info['owner'], self.meta_info['repo'], self.meta_info['branch'], self.meta_info['commit'], self.meta_info['base_owner'], self.meta_info['base_repo'], self.meta_info['pr_number']]
 
 
 def get_core_info_push_file(json_path):
@@ -132,6 +132,7 @@ def get_core_info_pull_request_str(json_data):
         'branch': json_data['pull_request']['head']['ref'] if 'ref' in json_data['pull_request']['head'] else "unknown",
         'commit': json_data['pull_request']['head']['sha'] if 'sha' in json_data['pull_request']['head'] else "unknown",
         'statuses_url': json_data['pull_request']['statuses_url'] if 'statuses_url' in json_data['pull_request'] else "unknown",
+        'pr_number': json_data['pull_request']['number'] if 'number' in json_data['pull_request'] else "unknown"
     }
 
 

--- a/test.py
+++ b/test.py
@@ -19,7 +19,7 @@ import gakoci
 import json
 import uuid
 
-YOU = "monperrus"
+YOU = "surli"
 
 
 def create_pull_request(args):
@@ -77,6 +77,7 @@ class HelperTestCase(unittest.TestCase):
             'test/resources/pull_request_event.json')['commit'])
         self.assertEqual("https://api.github.com/repos/INRIA/spoon/statuses/e640b870f24eb7fc1078d36a4657b556874119e5",
                          gakoci.get_core_info_pull_request_file('test/resources/pull_request_event.json')['statuses_url'])
+        self.assertEqual("930", gakoci.get_core_info_pull_request_file('test/resources/pull_request_event.json')['pr_number'])
 
 
 class CoreTestCase(unittest.TestCase):


### PR DESCRIPTION
As described [here](https://help.github.com/articles/checking-out-pull-requests-locally/) it's pretty easy to get the merged commit of a PR using Github own branch but you must have the PR number. 
I slightly change Gakoci to be able to retrieve it and pass it to the PR hook. 
However I was not able to execute tests... 